### PR TITLE
bug Enable highlighter feature conditionally

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,11 +1,12 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
-require('./src/insert-unit-test-file.js');
-require('./src/read-only-lines.js');
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
-function activate() {}
+function activate() {
+    require('./src/insert-unit-test-file.js');
+    require('./src/read-only-lines.js');
+}
 
 exports.activate = activate;
 

--- a/src/read-only-lines.js
+++ b/src/read-only-lines.js
@@ -1,6 +1,9 @@
 /* The following piece of code highlights any read-only lines in the current
 text selection. */
 
+// Gets a reference to some Node core modules.
+const path = require('path');
+
 // Gets a reference to the VS Code API.
 const vscode = require('vscode');
 const { window } = vscode;
@@ -15,11 +18,53 @@ const TOP_LINES = 20;
 const BOTTOM_LINES = 8;
 
 
+/** Enables the highlighting feature as long as certain conditions are met.
+ * @param {TextEditor} textEditor - The text editor that has just gained focus.
+ * @listens onDidChangeActiveTextEditor
+ */
+function enableHighlighterIfRequired(textEditor){
+    // Disables the highlighter feature that may be on in some other document.
+    disposable.dispose();
+    // Gets the file name of the file attached to the active document.
+    const FILE_NAME = path.basename(textEditor.document.uri.fsPath);
+    // If the file name ends with '.spec.html'.
+    if (FILE_NAME.endsWith('.spec.html')) {
+        // Enables the highlighter feature in the active document.
+        disposable = window.onDidChangeTextEditorSelection(highlightIfRequired);
+    }
+}
+
+
+/** Gets each of the lines in the provided text selection.
+ * @param {Selection} selection - A text selection.
+ * @returns {[TextLine]} - An array of the lines in the text selection.
+ */
+function getLines(selection) {
+    // Gets a reference to the current document.
+    const document = window.activeTextEditor.document;
+    // Gets the line number of the topmost line in the text selection.
+    const START = selection.start.line;
+    // Gets the line number of the bottommost line in the text selection.
+    const END = selection.end.line + 1;
+    // Creates an array that will consist of the lines in the text selection.
+    const lines = [];
+    // For each line number in the text selection.
+    for (let i = START; i < END; i++) {
+        // Gets a reference to the associated line in the document.
+        let line = document.lineAt(i);
+        // Puts this reference in the array of lines.
+        lines.push(line);
+    }
+    // Returns the array of references to the lines in the text selection.
+    return lines;
+}
+
+
 /** Highlights any read-only lines on the same line as the caret and in the
  * current text selection.
  * @listens {onDidChangeTextEditorSelection}
  */
-function highlightIfNecessary(event) {
+function highlightIfRequired(event) {
     // Gets a reference to the active text editor.
     const { activeTextEditor } = window;
     // Gets each of the lines in the current text selection.
@@ -40,31 +85,6 @@ function highlightIfNecessary(event) {
 }
 
 
-/** Gets each of the lines in the provided text selection.
- * @param {Selection} selection - A text selection.
- * @returns {[TextLine]} - An array of the lines in the text selection.
- */
-function getLines(selection) {
-    // gets a reference to the current document.
-    const document = window.activeTextEditor.document;
-    // gets the line number of the topmost line in the text selection.
-    const START = selection.start.line;
-    // gets the line number of the bottommost line in the text selection.
-    const END = selection.end.line + 1;
-    // creates an array that will consist of the lines in the text selection.
-    const lines = [];
-    // for each line number in the text selection.
-    for (let i = START; i < END; i++) {
-        // gets a reference to the associated line in the document.
-        let line = document.lineAt(i);
-        // puts this reference in the array of lines.
-        lines.push(line);
-    }
-    // returns the array of references to the lines in the text selection.
-    return lines;
-}
-
-
 /** Checks if the line provided is read-only.
  * @param {TextLine} line - A line in the document.
  * @returns {Boolean} - Whether the line is read-only.
@@ -78,5 +98,9 @@ function isReadOnly(line) {
     return LINE_NUMBER < TOP_LINES || LINE_NUMBER >= LINE_COUNT - BOTTOM_LINES;
 }
 
-// highlights a read-only line if it detects one.
-window.onDidChangeTextEditorSelection(highlightIfNecessary);
+// Highlights a read-only line if it detects one.
+let disposable = window.onDidChangeTextEditorSelection(highlightIfRequired);
+disposable;
+
+// Enables the highlighting feature as long as certain conditions are met.
+window.onDidChangeActiveTextEditor(enableHighlighterIfRequired);


### PR DESCRIPTION
Highlighting of read-only lines was enabled for absolutely all files. Now,
it is enabled for unit test files only. That is, files ending with the
substring .spec.html.